### PR TITLE
Extend test timeouts

### DIFF
--- a/cmd/dlv/conftamer_test.go
+++ b/cmd/dlv/conftamer_test.go
@@ -881,7 +881,7 @@ func run(t *testing.T, config *ct.Config, expected_events []ct.Event) {
 	waitForServer(t, &server_out, &server_err)
 
 	// Run dlv client until exit or timeout
-	client_timeout := 10 * time.Second
+	client_timeout := 30 * time.Second
 	ctx, cancel = context.WithTimeout(context.Background(), client_timeout)
 	defer cancel()
 
@@ -896,7 +896,7 @@ func run(t *testing.T, config *ct.Config, expected_events []ct.Event) {
 	if err := client.Run(); err != nil {
 		if err.Error() == "signal: killed" {
 			// Can occur with some tests, but not when run outside `go test`
-			t.Logf("Test OOM - may cause failure if occurred before end")
+			t.Logf("Test timeout or OOM - may cause failure if occurred before end")
 		} else {
 			t.Logf("Client exited with error: %v\n", err.Error())
 			t.Fail()

--- a/conftamer/pre-commit-hook.py
+++ b/conftamer/pre-commit-hook.py
@@ -53,7 +53,7 @@ for test_name, test_group in test_groups.items():
   failed = False
 
   for test in tests:
-    test_cmd = f'go test -v -timeout 30s -run {test} github.com/go-delve/delve/{test_group.test_path} -count=1 -failfast'
+    test_cmd = f'go test -v -timeout 45s -run {test} github.com/go-delve/delve/{test_group.test_path} -count=1 -failfast'
     print(test_cmd)
     try:
       p = subprocess.run(test_cmd, shell=True, check=True, text=True, capture_output=True)


### PR DESCRIPTION
Currently, some of the tests fail because the client gets killed before the end of the test, which we previously thought was because of an OOM error. However, those tests take longer than 10s to run and the client is run with only a 10s timeout. Extending the timeouts fixes it.