### PR TITLE
Added slog mode to config

### DIFF
--- a/cmd/dlv/conftamer_test.go
+++ b/cmd/dlv/conftamer_test.go
@@ -193,6 +193,7 @@ func Config(testfile string, initial_watchexpr string, initial_line int) ct.Conf
 		Event_log_filename:    "event_log.csv",
 		Behavior_map_filename: "behavior_map.csv",
 		Server_endpoint:       "localhost:4040",
+		LoggerLevel:           "info",
 	}
 	return c
 }

--- a/conftamer/config.go
+++ b/conftamer/config.go
@@ -4,10 +4,13 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
+	"log/slog"
 
 	yaml "gopkg.in/yaml.v2"
 )
 
+type LogLevel string
 type Config struct {
 	/* Test params */
 	// If setting initial watchpoint immediately, the goroutine and frame
@@ -38,6 +41,7 @@ type Config struct {
 	Ignore_msg_recvs bool `yaml:"ignore_msg_recvs"`
 	// Target config API endpoint
 	Config_API_endpoint string `yaml:"config_api_endpoint"`
+	LoggerLevel string `yaml:"logger_level"`
 }
 
 func LoadConfig(file string) (*Config, error) {
@@ -78,4 +82,19 @@ func SaveConfig(file string, conf Config) error {
 
 	_, err = f.Write(out)
 	return err
+}
+
+func (c *Config) Level() slog.Level {
+	switch strings.ToLower(c.LoggerLevel) {
+	case "debug":
+		return slog.LevelDebug
+	case "info":
+		return slog.LevelInfo
+	case "warn":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	}
+	//default log level
+	return slog.LevelInfo
 }

--- a/conftamer/config.go
+++ b/conftamer/config.go
@@ -41,6 +41,7 @@ type Config struct {
 	Ignore_msg_recvs bool `yaml:"ignore_msg_recvs"`
 	// Target config API endpoint
 	Config_API_endpoint string `yaml:"config_api_endpoint"`
+	// Options are "debug", info", "warn", "error" corresponding to these SLOG levels https://pkg.go.dev/log/slog#Level
 	LoggerLevel string `yaml:"logger_level"`
 }
 

--- a/conftamer/hits.go
+++ b/conftamer/hits.go
@@ -694,7 +694,7 @@ func New(config *Config) (*TaintCheck, error) {
 	}
 
 	// TODO (minor) make log level configurable
-	tc.logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{AddSource: true, Level: slog.LevelInfo,
+	tc.logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{AddSource: true, Level: config.Level(),
 		// Shorten paths for client filenames
 		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
 			if a.Key == slog.SourceKey {


### PR DESCRIPTION
1. Modified conftamer_test.go to use the LoggerLevel="info" for the tests
2. Modified config.go to accept a string LoggerLevel of "info", "debug", "warn", or "error" in the YAML